### PR TITLE
Segmentation fault error during federated execution caused by multiport

### DIFF
--- a/lib/pythontarget.c
+++ b/lib/pythontarget.c
@@ -412,11 +412,8 @@ void destroy_action_capsule(PyObject* capsule) {
  * Individual ports can then later be accessed in Python code as port[idx].
  */
 PyObject* convert_C_port_to_py(void* port, int width) {
-    generic_port_instance_struct* cport;
-    if (width == -2) {
-        // Not a multiport
-        cport = (generic_port_instance_struct *)port;
-    }
+    generic_port_instance_struct* cport = (generic_port_instance_struct *)port;
+
     // Create the port struct in Python
     PyObject* cap =
         (PyObject*)PyObject_GC_New(generic_port_capsule_struct, &py_port_capsule_t);


### PR DESCRIPTION
This pull request addresses the issue found in the `convert_C_port_to_py` function. The problem occurs when handling `generic_port_instance_struct* cport` for multiport instances. Currently, this structure is not properly assigned when dealing with multiport instances, which leads to subsequent issues in the function. On line 433, we see the macro `FEDERATED_ASSIGN_FIELDS(((generic_port_capsule_struct*)cap), cport)`, which relies on cport. In the case of multiport, if cport isn't appropriately assigned, this macro won't function correctly, causing segmentation fault.